### PR TITLE
feat: add expo camera capabilities

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+			[ "expo-camera", { "cameraPermissions": "Test" } ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@expo/vector-icons": "^13.0.0",
 		"@react-navigation/native": "^6.0.2",
 		"expo": "~49.0.15",
+		"expo-camera": "~13.4.4",
 		"expo-dev-client": "~2.4.12",
 		"expo-font": "~11.4.0",
 		"expo-linking": "~5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,6 +3952,13 @@ expo-asset@~8.10.1:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
+expo-camera@~13.4.4:
+  version "13.4.4"
+  resolved "https://registry.yarnpkg.com/expo-camera/-/expo-camera-13.4.4.tgz#e01ead31a3150398d37e94c307f6937480680690"
+  integrity sha512-7k54APbpSulUDR2CrD5SrmKjCdfdg4tqKRpbBOKc2J2MIBHhunExU77435JDYSejHRY5bfRHZsEp3yKwR862uw==
+  dependencies:
+    invariant "^2.2.4"
+
 expo-constants@~14.4.2:
   version "14.4.2"
   resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-14.4.2.tgz"


### PR DESCRIPTION
BREAKING CHANGE: Expo camera adds native layer changes and thus requires a new app bundle to use the related features and receive future updates